### PR TITLE
chore: use `semantic-release` cross-formula standard structure

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -26,4 +26,5 @@ docker_builder:
       # - INSTANCE: default-fedora-28-2017-7-py2
       # - INSTANCE: default-opensuse-leap-42-2017-7-py2
   bundle_install_script: bundle install
-  verify_script: bin/kitchen verify ${INSTANCE}
+  verify_script:
+    - bin/kitchen verify ${INSTANCE}


### PR DESCRIPTION
* Automated using `ssf-formula` (v0.1.0-rc.5)